### PR TITLE
0.2.0.9000

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,5 @@
 # maestro 0.2.0.9000
 
-### New features
-
-- Added function `plot_schedule` to interactively or statically show the schedule for a given time interval (#88).
-
 ### Minor changes
 
 - Changed from `example_schedule` data the pipeline with a schedule of 1 minute to 30 minutes in keeping with best practices for minimum pipeline frequency.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # maestro 0.2.0.9000
 
+### Major changes
+
+- `maestroFrequency` tag now accepts the values hourly, daily, weekly, biweekly, monthly, quarterly, and yearly. Argument `orch_frequency` to `run_schedule()` also accepts these values.
+
 ### Minor changes
 
 - Changed from `example_schedule` data the pipeline with a schedule of 1 minute to 30 minutes in keeping with best practices for minimum pipeline frequency.

--- a/R/create_pipeline.R
+++ b/R/create_pipeline.R
@@ -4,7 +4,7 @@
 #'
 #' @param pipe_name name of the pipeline and function
 #' @param pipeline_dir directory containing the pipeline scripts
-#' @param frequency how often the pipeline should run (e.g., 1 day, 3 hours, 4 months). Fills in maestroFrequency tag
+#' @param frequency how often the pipeline should run (e.g., 1 day, daily, 3 hours, 4 months). Fills in maestroFrequency tag
 #' @param start_time start time of the pipeline schedule. Fills in maestroStartTime tag
 #' @param tz timezone that pipeline will be scheduled in. Fills in maestroTz tag
 #' @param log_level log level for the pipeline (e.g., INFO, WARN, ERROR). Fills in maestroLogLevel tag

--- a/R/maestro_tags.R
+++ b/R/maestro_tags.R
@@ -12,7 +12,7 @@
 #'
 #'  | tagName          | description                                                         | value             | examples (comma sep.)           | default             |
 #'  |------------------|---------------------------------------------------------------------|-------------------|---------------------------------|---------------------|
-#'  | maestroFrequency | Time unit for scheduling                                            | string            | 1 hour, 3 days, 5 weeks         | 1 day               |
+#'  | maestroFrequency | Time unit for scheduling                                            | string            | 1 hour, daily, 3 days, 5 weeks  | 1 day               |
 #'  | maestroLogLevel  | Threshold for logging when logging is requested                     | string            | INFO, WARN, ERROR               | INFO                |
 #'  | maestroSkip      | Skips the pipeline when running (presence of tag indicates to skip) | n/a               |                                 |                     |
 #'  | maestroStartTime | Start time of the pipeline; sets the point in time for recurrence   | date or timestamp | 1970-01-01 00:00:00, 2024-03-28 | 1970-01-01 00:00:00 |

--- a/R/roxy_maestro.R
+++ b/R/roxy_maestro.R
@@ -10,7 +10,8 @@ roxy_tag_parse.roxy_tag_maestroFrequency <- function(x) {
 
   if (x$raw == "") {
     x$val <- "1 day"
-  } else {
+
+  } else if (grepl("^[0-9]", x$raw)) {
 
     tryCatch({
       # Try to parse it using our function
@@ -25,11 +26,28 @@ roxy_tag_parse.roxy_tag_maestroFrequency <- function(x) {
         x,
         glue::glue(
           "Invalid maestroFrequency `{x$raw}`.
-          Must have a format of [number] [units] (e.g., 1 day, 2 weeks, 4 months, etc)"
+          Must have a format of [number] [units] (e.g., 1 day, 2 weeks, 4 months, etc)
+          or one of hourly, daily, weekly, etc."
         )
       )
       return()
     })
+
+  } else {
+
+    if (!x$raw %in% c("hourly", "daily", "weekly", "biweekly", "monthly", "quarterly", "yearly")) {
+      roxygen2::roxy_tag_warning(
+        x,
+        glue::glue(
+          "Invalid maestroFrequency `{x$raw}`.
+          Must have a format of [number] [units] (e.g., 1 day, 2 weeks, 4 months, etc)
+          or one of hourly, daily, weekly, etc."
+        )
+      )
+      return()
+    }
+
+    x$val <- x$raw
   }
 
   x

--- a/R/run_schedule.R
+++ b/R/run_schedule.R
@@ -34,7 +34,7 @@
 #'
 #' @param schedule a table of scheduled pipelines generated from `build_schedule()`
 #' @inheritParams check_pipelines
-#' @param orch_frequency of the orchestrator, a single string formatted like "1 day" or "2 weeks"
+#' @param orch_frequency of the orchestrator, a single string formatted like "1 day", "2 weeks", "hourly", etc.
 #' @param resources named list of shared resources made available to pipelines as needed
 #' @param run_all run all pipelines regardless of the schedule (default is `FALSE`) - useful for testing.
 #' Does not apply to pipes with a `maestroSkip` tag.
@@ -90,7 +90,7 @@ run_schedule <- function(
     cli::cli_abort(
       c(
         "Invalid `orch_frequency` {orch_frequency}.",
-        "i" = "Must be of the format like '1 day', '2 weeks', etc."
+        "i" = "Must be of the format like '1 day', '2 weeks', 'hourly', etc."
       ),
       call = NULL
     )
@@ -99,7 +99,7 @@ run_schedule <- function(
   # Additional parse using timechange to verify it isn't something like 500 days,
   # which isn't understood by timechange
   tryCatch({
-    timechange::time_round(Sys.time(), orch_frequency)
+    timechange::time_round(Sys.time(), paste(orch_nunits$n, orch_nunits$unit))
   }, error = \(e) {
     timechange_error_fmt <- gsub('\\..*', '', e$message)
     cli::cli_abort(

--- a/R/suggest_orch_frequency.R
+++ b/R/suggest_orch_frequency.R
@@ -78,7 +78,7 @@ suggest_orch_frequency <- function(schedule, check_datetime = lubridate::now(tzo
 
     if (typeof(schedule$skip) != "logical") {
       cli::cli_abort(
-        c("Schedule columns {.code skip} must have type 'character'.",
+        c("Schedule columns {.code skip} must have type 'logical'.",
           "i" = "Use {.fn build_schedule} to create a valid schedule."),
         call = rlang::caller_env()
       )

--- a/R/utils.R
+++ b/R/utils.R
@@ -162,7 +162,7 @@ valid_units <- c(
 
 #' Parse a time string
 #'
-#' @param time_string string like 1 day, 2 weeks, 12 hours, etc.
+#' @param time_string string like 1 day, daily, 2 weeks, 12 hours, etc.
 #'
 #' @return nunit list
 parse_rounding_unit <- function(time_string) {
@@ -170,6 +170,19 @@ parse_rounding_unit <- function(time_string) {
   stopifnot("Must be a single string" = length(time_string) == 1)
 
   # Extract the number and the unit from the time string
+  if (!grepl("^[0-9]", time_string)) {
+    time_string <- switch (time_string,
+      hourly = "1 hour",
+      daily = "1 day",
+      weekly = "1 week",
+      biweekly = "2 weeks",
+      monthly = "1 month",
+      quarterly = "3 months",
+      yearly = "1 year",
+      time_string
+    )
+  }
+
   matches <- regmatches(time_string, regexec("([0-9]+)\\s*(\\w+)", time_string))
   number <- as.numeric(matches[[1]][2])
   unit <- matches[[1]][3]

--- a/man/create_pipeline.Rd
+++ b/man/create_pipeline.Rd
@@ -21,7 +21,7 @@ create_pipeline(
 
 \item{pipeline_dir}{directory containing the pipeline scripts}
 
-\item{frequency}{how often the pipeline should run (e.g., 1 day, 3 hours, 4 months). Fills in maestroFrequency tag}
+\item{frequency}{how often the pipeline should run (e.g., 1 day, daily, 3 hours, 4 months). Fills in maestroFrequency tag}
 
 \item{start_time}{start time of the pipeline schedule. Fills in maestroStartTime tag}
 

--- a/man/maestro_tags.Rd
+++ b/man/maestro_tags.Rd
@@ -11,7 +11,7 @@ of pipelines.
 maestro tags follow the format \verb{#' @maestroTagName}
 \subsection{Tag List}{\tabular{lllll}{
    tagName \tab description \tab value \tab examples (comma sep.) \tab default \cr
-   maestroFrequency \tab Time unit for scheduling \tab string \tab 1 hour, 3 days, 5 weeks \tab 1 day \cr
+   maestroFrequency \tab Time unit for scheduling \tab string \tab 1 hour, daily, 3 days, 5 weeks \tab 1 day \cr
    maestroLogLevel \tab Threshold for logging when logging is requested \tab string \tab INFO, WARN, ERROR \tab INFO \cr
    maestroSkip \tab Skips the pipeline when running (presence of tag indicates to skip) \tab n/a \tab  \tab  \cr
    maestroStartTime \tab Start time of the pipeline; sets the point in time for recurrence \tab date or timestamp \tab 1970-01-01 00:00:00, 2024-03-28 \tab 1970-01-01 00:00:00 \cr

--- a/man/parse_rounding_unit.Rd
+++ b/man/parse_rounding_unit.Rd
@@ -7,7 +7,7 @@
 parse_rounding_unit(time_string)
 }
 \arguments{
-\item{time_string}{string like 1 day, 2 weeks, 12 hours, etc.}
+\item{time_string}{string like 1 day, daily, 2 weeks, 12 hours, etc.}
 }
 \value{
 nunit list

--- a/man/run_schedule.Rd
+++ b/man/run_schedule.Rd
@@ -21,7 +21,7 @@ run_schedule(
 \arguments{
 \item{schedule}{a table of scheduled pipelines generated from \code{build_schedule()}}
 
-\item{orch_frequency}{of the orchestrator, a single string formatted like "1 day" or "2 weeks"}
+\item{orch_frequency}{of the orchestrator, a single string formatted like "1 day", "2 weeks", "hourly", etc.}
 
 \item{check_datetime}{datetime against which to check the running of pipelines (default is current system time in UTC)}
 

--- a/tests/testthat/_snaps/build_schedule.md
+++ b/tests/testthat/_snaps/build_schedule.md
@@ -3,14 +3,15 @@
     Code
       res
     Output
-      # A tibble: 6 x 8
+      # A tibble: 7 x 8
         script_path            pipe_name frequency start_time          skip  log_level
         <chr>                  <chr>     <chr>     <dttm>              <lgl> <chr>    
       1 test_pipelines_parse_~ get_mtca~ 1 day     2024-03-01 09:00:00 FALSE INFO     
       2 test_pipelines_parse_~ wait      3 month   1970-01-01 00:00:00 FALSE WARN     
       3 test_pipelines_parse_~ add       3 month   1970-01-01 00:00:00 FALSE INFO     
       4 test_pipelines_parse_~ something 3 month   1970-01-01 00:00:00 FALSE INFO     
-      5 test_pipelines_parse_~ get_mtca~ 1 day     2024-03-01 09:00:00 FALSE INFO     
-      6 test_pipelines_parse_~ pipe      30 minute 1970-01-01 00:00:00 FALSE INFO     
+      5 test_pipelines_parse_~ something daily     1970-01-01 00:00:00 FALSE INFO     
+      6 test_pipelines_parse_~ get_mtca~ 1 day     2024-03-01 09:00:00 FALSE INFO     
+      7 test_pipelines_parse_~ pipe      30 minute 1970-01-01 00:00:00 FALSE INFO     
       # i 2 more variables: frequency_n <int>, frequency_unit <chr>
 

--- a/tests/testthat/_snaps/run_schedule.md
+++ b/tests/testthat/_snaps/run_schedule.md
@@ -3,7 +3,7 @@
     Code
       status$invoked
     Output
-      [1] FALSE FALSE FALSE FALSE FALSE  TRUE
+      [1] FALSE FALSE FALSE FALSE FALSE FALSE  TRUE
 
 ---
 
@@ -12,14 +12,15 @@
     Output
       [1] "2024-04-26 09:00:00 UTC" "2024-04-25 13:00:00 UTC"
       [3] "2024-07-01 07:30:00 UTC" "2024-05-02 00:00:00 UTC"
-      [5] "5000-12-12 10:15:00 UTC" "2024-04-25 10:30:00 UTC"
+      [5] "5000-12-12 10:15:00 UTC" "2024-05-02 00:00:00 UTC"
+      [7] "2024-04-25 10:30:00 UTC"
 
 ---
 
     Code
       status$invoked
     Output
-      [1]  TRUE  TRUE  TRUE FALSE FALSE  TRUE
+      [1]  TRUE  TRUE  TRUE FALSE FALSE FALSE  TRUE
 
 ---
 
@@ -27,14 +28,14 @@
       status$next_run
     Output
       [1] "2024-05-01 UTC" "2024-05-01 UTC" "2024-07-01 UTC" "2024-05-01 UTC"
-      [5] "5000-12-01 UTC" "2024-05-01 UTC"
+      [5] "5000-12-01 UTC" "2024-05-01 UTC" "2024-05-01 UTC"
 
 ---
 
     Code
       status$invoked
     Output
-      [1]  TRUE  TRUE  TRUE FALSE FALSE  TRUE
+      [1]  TRUE  TRUE  TRUE FALSE FALSE FALSE  TRUE
 
 ---
 
@@ -42,5 +43,5 @@
       status$next_run
     Output
       [1] "2024-04-05 UTC" "2024-04-05 UTC" "2024-07-01 UTC" "2024-04-05 UTC"
-      [5] "5000-12-13 UTC" "2024-04-05 UTC"
+      [5] "5000-12-13 UTC" "2024-04-05 UTC" "2024-04-05 UTC"
 

--- a/tests/testthat/test-roclets.R
+++ b/tests/testthat/test-roclets.R
@@ -1,7 +1,16 @@
-test_that("parse maestroFrequency tag works", {
+test_that("parse maestroFrequency tag works with '1 day'", {
   res <- roxygen2::roc_proc_text(
     maestroFrequency_roclet(),
     readLines(test_path("test_pipelines/test_pipeline_daily_good.R"))
+  ) |>
+    expect_no_message()
+  expect_type(res$val, "character")
+})
+
+test_that("parse maestroFrequency tag works with 'daily'", {
+  res <- roxygen2::roc_proc_text(
+    maestroFrequency_roclet(),
+    readLines(test_path("test_pipelines/test_pipeline_daily_single_good.R"))
   ) |>
     expect_no_message()
   expect_type(res$val, "character")
@@ -22,6 +31,16 @@ test_that("bad usage of maestroFrequency warns and gives no val", {
   res <- roxygen2::roc_proc_text(
     maestroFrequency_roclet(),
     readLines(test_path("test_pipelines/test_pipeline_daily_bad.R"))
+  ) |>
+    expect_warning(regexp = "Must have a format")
+
+  expect_null(res$val)
+})
+
+test_that("bad usage of maestroFrequency warns and gives no val", {
+  res <- roxygen2::roc_proc_text(
+    maestroFrequency_roclet(),
+    readLines(test_path("test_pipelines/test_pipeline_daily_single_bad.R"))
   ) |>
     expect_warning(regexp = "Must have a format")
 

--- a/tests/testthat/test-run_schedule.R
+++ b/tests/testthat/test-run_schedule.R
@@ -69,7 +69,7 @@ test_that("run_schedule works on different kinds of frequencies", {
 
   test_freqs <- c("14 days", "10 minutes", "25 mins", "1 week",
                   "1 quarter", "12 months", "4 years", "24 hours",
-                  "31 days", "1 secs", "50 seconds")
+                  "31 days", "1 secs", "50 seconds", "daily", "hourly", "weekly")
 
   purrr::walk(test_freqs, ~{
     expect_no_error({

--- a/tests/testthat/test-suggest_orch_frequency.R
+++ b/tests/testthat/test-suggest_orch_frequency.R
@@ -73,8 +73,23 @@ test_that("suggest_orch_frequency gives expected errors", {
   )
 
   expect_error(
+    suggest_orch_frequency(data.frame(frequency = "1 day")),
+    regexp = "Schedule is missing required column 'start_time'"
+  )
+
+  expect_error(
     suggest_orch_frequency(data.frame(frequency = c("1 potato", "1 month"), start_time = Sys.time() + 0:1)),
     regexp = "invalid time units"
+  )
+
+  expect_error(
+    suggest_orch_frequency(data.frame(frequency = c("1 day", "1 month"), start_time = c("a", "b"))),
+    regexp = "Schedule columns `start_time`"
+  )
+
+  expect_error(
+    suggest_orch_frequency(data.frame(frequency = c("daily", "1 month"), start_time = Sys.time() + 0:1, skip = "hello")),
+    regexp = "Schedule columns `skip`"
   )
 })
 

--- a/tests/testthat/test-suggest_orch_frequency.R
+++ b/tests/testthat/test-suggest_orch_frequency.R
@@ -77,3 +77,47 @@ test_that("suggest_orch_frequency gives expected errors", {
     regexp = "invalid time units"
   )
 })
+
+test_that("suggest_orch_frequency does not consider skipped pipelines", {
+
+  test_schedule <- data.frame(
+    frequency = c("1 days", "3 days", "6 days"),
+    frequency_n = c(1, 3, 6),
+    frequency_unit = c("day", "day", "day"),
+    start_time = as.POSIXct("2024-06-04"),
+    skip = c(TRUE, FALSE, FALSE)
+  )
+
+  expect_equal(
+    suggest_orch_frequency(test_schedule),
+    "3 days"
+  )
+
+  test_schedule <- data.frame(
+    frequency = c("1 days", "3 days", "6 days"),
+    frequency_n = c(1, 3, 6),
+    frequency_unit = c("day", "day", "day"),
+    start_time = as.POSIXct("2024-06-04"),
+    skip = TRUE
+  )
+
+  expect_error(
+    suggest_orch_frequency(test_schedule),
+    regexp = "No pipelines in schedule after removing skipped"
+  )
+})
+
+test_that("suggest_orch_frequency works with a single pipeline", {
+
+  test_schedule <- data.frame(
+    frequency = "1 day",
+    frequency_n = 1,
+    frequency_unit = "day",
+    start_time = as.POSIXct("2024-01-01")
+  )
+
+  expect_equal(
+    suggest_orch_frequency(test_schedule),
+    "1 day"
+  )
+})

--- a/tests/testthat/test_pipelines/test_pipeline_daily_single_bad.R
+++ b/tests/testthat/test_pipelines/test_pipeline_daily_single_bad.R
@@ -1,0 +1,11 @@
+#' Simple mtcars print function
+#'
+#' @maestroFrequency minutely
+#' @maestroStartTime 2024-03-01 09:00:00
+#' @maestroTz UTC
+#'
+#'
+#' @export
+get_mtcars <- function() {
+  mtcars
+}

--- a/tests/testthat/test_pipelines/test_pipeline_daily_single_good.R
+++ b/tests/testthat/test_pipelines/test_pipeline_daily_single_good.R
@@ -1,0 +1,14 @@
+#' Simple mtcars print function
+#'
+#' This is a function that runs every hour starting at
+#' 2024-03-01 09:00:00
+#'
+#' @maestroFrequency daily
+#' @maestroStartTime 2024-03-01 09:00:00
+#' @maestroTz UTC
+#'
+#'
+#' @export
+get_mtcars <- function() {
+  mtcars
+}

--- a/tests/testthat/test_pipelines_parse_all_good/pipe1.R
+++ b/tests/testthat/test_pipelines_parse_all_good/pipe1.R
@@ -43,3 +43,13 @@ add <- function() {
 something <- function() {
   invisible()
 }
+
+#' Daily
+#'
+#' @maestroFrequency daily
+#' @maestroStartTime 1970-01-01 00:00:00 ADT
+#'
+#' @export
+something <- function() {
+  invisible()
+}

--- a/tests/testthat/test_pipelines_run_all_good/pipe1.R
+++ b/tests/testthat/test_pipelines_run_all_good/pipe1.R
@@ -34,3 +34,10 @@ weekly <- function() {
 way_in_the_future <- function() {
   invisible()
 }
+
+#' @maestroFrequency weekly
+#'
+#' @export
+weekly2 <- function() {
+  1 + 1
+}

--- a/vignettes/maestro-1-quick-start.Rmd
+++ b/vignettes/maestro-1-quick-start.Rmd
@@ -52,7 +52,7 @@ A pipeline is simply an R function with decorators called maestro tags. Maestro 
 ```{r}
 #' my_pipe maestro pipeline
 #'
-#' @maestroFrequency 1 day
+#' @maestroFrequency daily
 #' @maestroStartTime 2024-05-24
 #' @maestroTz UTC
 #' @maestroLogLevel INFO
@@ -63,9 +63,11 @@ my_pipe <- function() {
 }
 ```
 
-`my_pipe` is a function with an empty body - so right now it won't do anything. The comments above are interpreted by `maestro` as "this function is scheduled to run every 1 day starting at 2024-05-24 (00:00:00) UTC time".
+`my_pipe` is a function with an empty body - so right now it won't do anything. The comments above are interpreted by `maestro` as "this function is scheduled to run every day starting at 2024-05-24 (00:00:00) UTC time".
 
-Note that you don't need to provide all these tags. A single maestro tag is enough to distinguish it as a pipeline. Pipelines missing tags will use consistent defaults (e.g., if `maestroFrequency` is missing the default is 1 day).
+maestroFrequency and maestroStartTime are the most important tags for scheduling. Frequency is how often you want the pipeline to run and can be formatted as a single string like hourly, daily, weekly, biweekly, etc. or with a number and a unit (e.g., 1 day, 3 hours, etc.).
+
+Note that you don't need to provide all these tags. A single maestro tag is enough to distinguish it as a pipeline. Pipelines missing tags will use consistent defaults (e.g., if `maestroFrequency` is missing the default is 1 day/daily).
 
 In most use cases, the actual code inside of `my_pipe` would be to run an ETL job (extract data from a source, transform it, and load it into a file system or database). In technical terms, it's the *side effect* of the code and not its return value that is important.
 
@@ -74,7 +76,7 @@ Here's a more realistic, albeit impractical, example:
 ```{r}
 #' my_pipe maestro pipeline
 #'
-#' @maestroFrequency 1 day
+#' @maestroFrequency daily
 #' @maestroStartTime 2024-05-24
 #' @maestroTz UTC
 #' @maestroLogLevel INFO


### PR DESCRIPTION
# maestro 0.2.0.9000

### Major changes

- `maestroFrequency` tag now accepts the values hourly, daily, weekly, biweekly, monthly, quarterly, and yearly. Argument `orch_frequency` to `run_schedule()` also accepts these values.

### Minor changes

- Changed from `example_schedule` data the pipeline with a schedule of 1 minute to 30 minutes in keeping with best practices for minimum pipeline frequency.

- `suggest_orch_frequency` now uses the smallest interval between any two pipelines (#99).

### Bug Fixes

- Error messages on unintentional overwrites from `create_*()` functions correctly reference name of path or directory that was to be overwritten.

- Fixed cli output of `run_schedule()` to not show skipped pipelines in the next run portion.