### PR TITLE
fix issue with hours, days, months, specs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,11 +8,13 @@
 
 ### Bug fixes
 
-- Specifying maestroHours, maestroDays, maestroMonths now correctly adopts the time zone specified in maestroTz (#141).
+- Specifying `maestroHours`, `maestroDays`, `maestroMonths` now correctly adopts the time zone specified in `maestroTz` (#141).
 
-- When using non UTC time zones, the presence of Daylight Savings Time in the maestroStartTime is used to adjust the sequence so that invocations occur on the same time interval.
+- When using non UTC time zones, the presence of Daylight Savings Time in the `maestroStartTime` is used to adjust the sequence so that invocations occur on the same time interval.
 
-- Other time zone fixes to deal with differing maestroTz and system time checks.
+- Other time zone fixes to deal with differing `maestroTz` and system time checks.
+
+- `maestroHours`, was only valid when `maestroFrequency` was specified as 'hourly', but now '1 hour' is also acceptable (same applies for other specifier tags).
 
 # maestro 0.5.1
 

--- a/R/build_schedule_entry.R
+++ b/R/build_schedule_entry.R
@@ -154,7 +154,7 @@ build_schedule_entry <- function(script_path) {
     purrr::walk2(pipe_names, maestro_tag_vals, ~{
 
       # Validate hours
-      if (!all(is.na(maestro_tag_vals[[1]]$hours)) && !maestro_tag_vals[[1]]$frequency %in% c("hourly")) {
+      if (!all(is.na(maestro_tag_vals[[1]]$hours)) && !maestro_tag_vals[[1]]$frequency %in% c("hourly", "1 hour")) {
         cli::cli_abort(
           c("If specifying `@maestroHours` the pipeline must have a `@maestroFrequency` of 'hourly'.",
             "i" = "Issue is with pipeline named {.x}."),
@@ -163,7 +163,8 @@ build_schedule_entry <- function(script_path) {
       }
 
       # Validate days
-      if (!all(is.na(maestro_tag_vals[[1]]$days)) && !maestro_tag_vals[[1]]$frequency %in% c("daily", "hourly")) {
+      if (!all(is.na(maestro_tag_vals[[1]]$days)) &&
+          !maestro_tag_vals[[1]]$frequency %in% c("daily", "hourly", "1 day", "1 hour")) {
         cli::cli_abort(
           c("If specifying `@maestroDays` the pipeline must have a `@maestroFrequency` of 'daily' or 'hourly'.",
             "i" = "Issue is with pipeline named {.x}."),
@@ -173,7 +174,7 @@ build_schedule_entry <- function(script_path) {
 
       # Validate months
       if (!all(is.na(maestro_tag_vals[[1]]$months)) && !maestro_tag_vals[[1]]$frequency %in%
-          c("monthly", "biweekly", "weekly", "daily", "hourly")) {
+          c("monthly", "biweekly", "weekly", "daily", "hourly", "1 month", "1 week", "1 day", "1 hour")) {
         cli::cli_abort(
           c("If specifying `@maestroMonths` the pipeline must have a `@maestroFrequency` of
           'monthly', 'biweekly', 'weekly', 'daily', or 'hourly'.",

--- a/R/utils.R
+++ b/R/utils.R
@@ -259,16 +259,3 @@ adjust_for_dst <- function(base_timestamp, adjustable_timestamps) {
 
   adjustable_timestamps + lubridate::hours(adjustment)
 }
-
-inflate_by_dst <- function(base_timestamp, adjustable_timestamps) {
-
-  base_dst <- lubridate::dst(base_timestamp)
-
-  adjustment <- ifelse(
-    lubridate::dst(adjustable_timestamps) == base_dst,
-    0,
-    1
-  )
-
-  adjustable_timestamps + lubridate::hours(adjustment)
-}

--- a/tests/testthat/test-build_schedule_entry.R
+++ b/tests/testthat/test-build_schedule_entry.R
@@ -119,3 +119,26 @@ test_that("Pipelines with maestro tag get picked up", {
   )
   expect_equal(length(res$MaestroPipelines), 1)
 })
+
+test_that("Pipelines with maestroHours and maestroFrequency = 1 hour are valid", {
+
+  withr::with_tempdir({
+    dir.create("pipelines")
+    writeLines(
+      "
+      #' @maestroTz America/Halifax
+      #' @maestroFrequency 1 hour
+      #' @maestroStartTime 2025-01-01 00:00:00
+      #' @maestroHours 0 4 7 12 18
+      hourly <- function() {
+
+      }
+      ",
+      con = "pipelines/hourly.R"
+    )
+
+    expect_no_error({
+      build_schedule_entry("pipelines/hourly.R")
+    })
+  })
+})


### PR DESCRIPTION
# maestro 0.5.2

### Minor changes

- Pipeline schedule sequences are now stored internally inside of `<MaestroPipeline>` objects instead of generated during `run_schedule()`. This has implications when caching a schedule as the sequence only goes out 3 years in advance.

- Performance improvements to `run_schedule()`.

### Bug fixes

- Specifying `maestroHours`, `maestroDays`, `maestroMonths` now correctly adopts the time zone specified in `maestroTz` (#141).

- When using non UTC time zones, the presence of Daylight Savings Time in the `maestroStartTime` is used to adjust the sequence so that invocations occur on the same time interval.

- Other time zone fixes to deal with differing `maestroTz` and system time checks.

- `maestroHours`, was only valid when `maestroFrequency` was specified as 'hourly', but now '1 hour' is also acceptable (same applies for other specifier tags).