### PR TITLE
0.6.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: maestro
 Type: Package
 Title: Orchestration of Data Pipelines
-Version: 0.6.0
+Version: 0.6.1
 Authors@R: 
     c(
       person("Will", "Hipson", , "will.e.hipson@gmail.com", role = c("cre", "aut", "cph"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# maestro 0.6.1
+
+### Bug fixes
+
+- `maestro::invoke()` now properly passes resources (arguments) to pipelines (#157).
+
+- Number of errors reported in `get_status()` is now accurately reported.
+
 # maestro 0.6.0
 
 ### New features

--- a/R/MaestroPipeline.R
+++ b/R/MaestroPipeline.R
@@ -322,7 +322,7 @@ MaestroPipeline <- R6::R6Class(
         success = invoked && private$status != "Error",
         pipeline_started = private$run_time_start,
         pipeline_ended = private$run_time_end,
-        errors = length(private$errors),
+        errors = length(private$errors$message),
         warnings = length(private$warnings),
         messages = length(private$messages),
         next_run = private$next_run

--- a/R/invoke.R
+++ b/R/invoke.R
@@ -71,5 +71,25 @@ invoke <- function(schedule, pipe_name, resources = list(), ...) {
   pipeline_idx <- which(pipe_names == pipe_name)
   pipeline_to_run <- schedule$PipelineList$MaestroPipelines[[pipeline_idx]]
 
-  pipeline_to_run$run(...)
+  tryCatch({
+    pipeline_to_run$run(..., resources = resources)
+  }, error = function(e) {
+
+    if (e$message == "unused argument (`NA` = NULL)") {
+      cli::cli_abort(
+        c(
+          "Failed to invoke pipeline {.code {pipe_name}}",
+          "i" = "Did you forget to pass pipeline arguments as `resources = list(name = val)`?"
+        ),
+        call = NULL
+      )
+    } else {
+      cli::cli_abort(
+        "Failed to invoke pipeline {.code {pipe_name}}",
+        call = NULL
+      )
+    }
+  })
+
+  return(invisible())
 }

--- a/tests/testthat/_snaps/MaestroPipeline.md
+++ b/tests/testthat/_snaps/MaestroPipeline.md
@@ -48,7 +48,7 @@
       # A tibble: 1 x 5
         invoked success errors warnings messages
         <lgl>   <lgl>    <int>    <int>    <int>
-      1 TRUE    FALSE        2        0        0
+      1 TRUE    FALSE        1        0        0
 
 # Pipeline with arguments are correctly passed
 

--- a/tests/testthat/test-invoke.R
+++ b/tests/testthat/test-invoke.R
@@ -39,3 +39,53 @@ test_that("invoke triggers the pipeline", {
   status <- schedule$get_status()
   expect_true(status$invoked[status$pipe_name == "chatty"])
 })
+
+test_that("invoke properly passes resources", {
+
+  withr::with_tempdir({
+    dir.create("pipelines")
+    writeLines(
+      "
+      #' @maestroFrequency hourly
+      times2 <- function(val) {
+        val * 2
+      }
+      ",
+      con = "pipelines/invoked.R"
+    )
+
+    schedule <- build_schedule(quiet = TRUE)
+
+    invoke(schedule, "times2", resources = list(val = 2), quiet = TRUE)
+
+    expect_true(get_status(schedule)$success)
+
+    expect_error(
+      invoke(schedule, "times2", quiet = TRUE),
+      regexp = "Did you forget"
+    )
+  })
+})
+
+test_that("invoke gives informative error message on failure", {
+
+  withr::with_tempdir({
+    dir.create("pipelines")
+    writeLines(
+      "
+      #' @maestroFrequency hourly
+      i_fail <- function() {
+        stop()
+      }
+      ",
+      con = "pipelines/invoked.R"
+    )
+
+    schedule <- build_schedule(quiet = TRUE)
+
+    expect_error(
+      invoke(schedule, "i_fail", quiet = TRUE),
+      regexp = "Failed to invoke"
+    )
+  })
+})

--- a/tests/testthat/test-run_schedule.R
+++ b/tests/testthat/test-run_schedule.R
@@ -348,6 +348,7 @@ test_that("run_schedule propagates warnings", {
     run_schedule(schedule, run_all = TRUE)
   })
   expect_gt(length(last_run_warnings()), 0)
+  expect_snapshot(get_status(schedule))
 }) |>
   suppressMessages()
 


### PR DESCRIPTION
# maestro 0.6.1

### Bug fixes

- `maestro::invoke()` now properly passes resources (arguments) to pipelines (#157).

- Number of errors reported in `get_status()` is now accurately reported.