### PR TITLE
fix issue with invoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ orchestrator.R
 inst/doc
 .DS_Store
 .Rprofile
+.dockerignore
+.Rbuildignore

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: maestro
 Type: Package
 Title: Orchestration of Data Pipelines
-Version: 0.7.0.9000
+Version: 0.6.2
 Authors@R: 
     c(
       person("Will", "Hipson", , "will.e.hipson@gmail.com", role = c("cre", "aut", "cph"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,12 @@
-# maestro 0.7.0.9000
+# maestro 0.6.2
 
 ### Minor changes
 
 - Console output of `run_schedule()` simplified. Counts of skipped pipelines removed to avoid confusion with `@maestroSkip` tag. 'Total' now refers to the total number of pipelines invoked in a run - not all pipelines in the project.
+
+### Bug fixes
+
+- `maestro::invoke()` only runs the selected pipeline or DAG rather than accidentally running all pipelines in the schedule (#161)
 
 # maestro 0.6.1
 

--- a/R/MaestroPipelineList.R
+++ b/R/MaestroPipelineList.R
@@ -68,6 +68,19 @@ MaestroPipelineList <- R6::R6Class(
     },
 
     #' @description
+    #' Get a MaestroPipelineList with selected pipelines
+    #' @param pipe_names names of the pipelines
+    #' @return MaestroPipelineList
+    get_pipes_by_name = function(pipe_names) {
+      names <- self$get_pipe_names()
+      names_idx <- which(names %in% pipe_names)
+      if (length(names_idx) == 0) {
+        cli::cli_abort("No pipelines named {pipe_names} in {.cls MaestroPipelineList}")
+      }
+      self$MaestroPipelines[names_idx]
+    },
+
+    #' @description
     #' Get priorities
     #' @return numeric
     get_priorities = function() {
@@ -322,6 +335,8 @@ MaestroPipelineList <- R6::R6Class(
 
       if (is.null(pipes_to_run)) {
         pipes_to_run <- self$get_primary_pipes()
+      } else {
+        pipes_to_run <- self$get_pipes_by_name(pipes_to_run)
       }
       network <- self$get_network()
 

--- a/R/invoke.R
+++ b/R/invoke.R
@@ -70,7 +70,7 @@ invoke <- function(schedule, pipe_name, resources = list(), ...) {
   }
 
   tryCatch({
-    schedule$PipelineList$run(..., resources = resources)
+    schedule$PipelineList$run(..., resources = resources, pipes_to_run = pipe_name)
   }, error = function(e) {
 
     if (e$message == "unused argument (`NA` = NULL)") {

--- a/man/MaestroPipelineList.Rd
+++ b/man/MaestroPipelineList.Rd
@@ -32,6 +32,7 @@ single script
 \item \href{#method-MaestroPipelineList-add_pipelines}{\code{MaestroPipelineList$add_pipelines()}}
 \item \href{#method-MaestroPipelineList-get_pipe_names}{\code{MaestroPipelineList$get_pipe_names()}}
 \item \href{#method-MaestroPipelineList-get_pipe_by_name}{\code{MaestroPipelineList$get_pipe_by_name()}}
+\item \href{#method-MaestroPipelineList-get_pipes_by_name}{\code{MaestroPipelineList$get_pipes_by_name()}}
 \item \href{#method-MaestroPipelineList-get_priorities}{\code{MaestroPipelineList$get_priorities()}}
 \item \href{#method-MaestroPipelineList-get_schedule}{\code{MaestroPipelineList$get_schedule()}}
 \item \href{#method-MaestroPipelineList-get_timely_pipelines}{\code{MaestroPipelineList$get_timely_pipelines()}}
@@ -136,6 +137,26 @@ Get a MaestroPipeline by its name
 }
 \subsection{Returns}{
 MaestroPipeline
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-MaestroPipelineList-get_pipes_by_name"></a>}}
+\if{latex}{\out{\hypertarget{method-MaestroPipelineList-get_pipes_by_name}{}}}
+\subsection{Method \code{get_pipes_by_name()}}{
+Get a MaestroPipelineList with selected pipelines
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{MaestroPipelineList$get_pipes_by_name(pipe_names)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{pipe_names}}{names of the pipelines}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+MaestroPipelineList
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-invoke.R
+++ b/tests/testthat/test-invoke.R
@@ -111,3 +111,30 @@ test_that("invoke triggers DAG pipelines", {
   })
 })
 
+test_that("invoke only runs the pipeline selected", {
+
+  withr::with_tempdir({
+    dir.create("pipelines")
+    writeLines(
+      "
+      #' @maestroFrequency hourly
+      pipe1 <- function() {
+        2
+      }
+
+      #' @maestroFrequency daily
+      pipe2 <- function() {
+        4
+      }
+      ",
+      con = "pipelines/invoked.R"
+    )
+
+    schedule <- build_schedule(quiet = TRUE)
+
+    invoke(schedule, "pipe2", quiet = TRUE)
+
+    expect_equal(sum(schedule$get_status()$invoked), 1)
+  })
+})
+


### PR DESCRIPTION
# maestro 0.6.2

### Minor changes

- Console output of `run_schedule()` simplified. Counts of skipped pipelines removed to avoid confusion with `@maestroSkip` tag. 'Total' now refers to the total number of pipelines invoked in a run - not all pipelines in the project.

### Bug fixes

- `maestro::invoke()` only runs the selected pipeline or DAG rather than accidentally running all pipelines in the schedule (#161)