### PR TITLE
fix critical bug with scheduler on long freq pipes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: maestro
 Type: Package
 Title: Orchestration of Data Pipelines
-Version: 0.6.2
+Version: 0.6.3
 Authors@R: 
     c(
       person("Will", "Hipson", , "will.e.hipson@gmail.com", role = c("cre", "aut", "cph"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# maestro 0.6.3
+
+### Bug fixes
+
+- Fixed issue with scheduler on certain frequencies over 1 month when the start time was less than 1 year ago.
+
 # maestro 0.6.2
 
 ### Minor changes

--- a/R/MaestroPipeline.R
+++ b/R/MaestroPipeline.R
@@ -85,7 +85,6 @@ MaestroPipeline <- R6::R6Class(
         private$days_of_week <- days_of_week %n% 1:7
         private$days_of_month <- days_of_month %n% 1:31
 
-
         # Create the run sequence
         start_time_adj <- private$start_time
 
@@ -96,9 +95,9 @@ MaestroPipeline <- R6::R6Class(
         })
 
         if (is_start_time_old) {
-          prev_year <- lubridate::year(lubridate::now()) - 1
+          floor_year <- lubridate::year(lubridate::now())
           start_time_adj <- lubridate::make_datetime(
-            year = prev_year,
+            year = floor_year,
             month = lubridate::month(private$start_time),
             day = lubridate::day(private$start_time),
             hour = lubridate::hour(private$start_time),


### PR DESCRIPTION
# maestro 0.6.3

### Bug fixes

- Fixed issue with scheduler on certain frequencies over 1 month when the start time was less than 1 year ago.