### PR TITLE
1.1.0.9001

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,6 @@ License: MIT + file LICENSE
 URL: https://github.com/whipson/maestro, https://whipson.github.io/maestro/
 BugReports: https://github.com/whipson/maestro/issues
 Encoding: UTF-8
-LazyData: true
 Imports: 
     cli (>= 3.3.0),
     dplyr (>= 1.1.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 
 ### New features
 
+- `get_run_sequence()` now returns an `is_primary` column: `TRUE` for pipelines that are not downstream nodes in a DAG (i.e., root or standalone pipelines), `FALSE` for downstream DAG nodes.
+
+- `get_run_sequence()` gains an `include_skipped` argument (default `TRUE`). Set to `FALSE` to exclude pipelines tagged with `@maestroSkip` from the output.
+
 - `maestroStartTime` now accepts partial anchor formats, making it easier to express natural cycle points without picking a specific date:
   - `Mon HH:MM:SS` (weekday + time) — for weekly pipelines, e.g. `Mon 04:00:00` runs every Monday at 4am.
   - `DD HH:MM:SS` or `DD` (month-day + optional time) — for monthly pipelines, e.g. `15 04:00:00` runs on the 15th of every month at 4am.

--- a/R/MaestroSchedule.R
+++ b/R/MaestroSchedule.R
@@ -266,39 +266,53 @@ MaestroSchedule <- R6::R6Class(
     #' @param max_datetime optional maximum datetime
     #' @param include_only_primary only primary pipelines are included 
     #'   (this are pipelines that are scheduled and not downstream nodes in a DAG)
+    #' @param include_skipped whether to include pipelines tagged with `@maestroSkip`
+    #'   (default `TRUE` for backwards compatibility)
     #' @return data.frame
-    get_run_sequence = function(n = NULL, min_datetime = NULL, max_datetime = NULL, include_only_primary = FALSE) {
-      run_sequence <- self$PipelineList$get_run_sequences(n = n, min_datetime = min_datetime, max_datetime = max_datetime) |> 
+    get_run_sequence = function(n = NULL, min_datetime = NULL, max_datetime = NULL, include_only_primary = FALSE, include_skipped = TRUE) {
+
+      pipeline_list <- self$PipelineList$MaestroPipelines
+
+      if (!include_skipped) {
+        pipeline_list <- purrr::discard(pipeline_list, ~isTRUE(.x$get_schedule()$skip))
+      }
+
+      run_sequence <- purrr::map(pipeline_list, ~.x$get_run_sequence(n = n, min_datetime = min_datetime, max_datetime = max_datetime)) |>
+        stats::setNames(purrr::map_chr(pipeline_list, ~.x$get_schedule()$pipe_name)) |>
+        purrr::discard(is.null) |>
         purrr::imap(
           ~dplyr::tibble(
             pipe_name = .y,
             scheduled_time = .x
           )
-        ) |> 
-        purrr::list_rbind() |> 
+        ) |>
+        purrr::list_rbind() |>
         dplyr::filter(!is.na(scheduled_time))
 
-      if (!include_only_primary) {
-        network <- self$get_network()
+      network <- self$get_network()
+      network$root <- find_roots(network$from, network$to)
 
-        network$root <- find_roots(network$from, network$to)
-        
+      # Primary = not a downstream DAG node
+      downstream_nodes <- network$to
+
+      if (!include_only_primary) {
         run_sequence_dags <- NULL
         if (nrow(network) > 0) {
           run_sequence_dags <- purrr::map2(network$to, network$root, ~{
-            run_sequence |> 
-              dplyr::filter(pipe_name == .y) |> 
+            run_sequence |>
+              dplyr::filter(pipe_name == .y) |>
               dplyr::mutate(pipe_name = .x)
-          }) |> 
+          }) |>
             purrr::list_rbind()
         }
 
-        run_sequence <- run_sequence |> 
-          dplyr::bind_rows(run_sequence_dags) |> 
+        run_sequence <- run_sequence |>
+          dplyr::bind_rows(run_sequence_dags) |>
           dplyr::arrange(scheduled_time)
       }
 
-      run_sequence
+      run_sequence |>
+        dplyr::mutate(is_primary = !pipe_name %in% downstream_nodes)
     }
   ),
 

--- a/R/get_run_sequence.R
+++ b/R/get_run_sequence.R
@@ -11,8 +11,11 @@
 #'   If specified, only returns runs scheduled at or before this datetime.
 #' @param include_only_primary only primary pipelines are included 
 #'   (this are pipelines that are scheduled and not downstream nodes in a DAG)
+#' @param include_skipped whether to include pipelines tagged with `@maestroSkip`
+#'   (default `TRUE` for backwards compatibility)
 #'
-#' @return A vector of datetime values representing the scheduled run times.
+#' @return A data.frame of scheduled run times with columns `pipe_name`, `scheduled_time`,
+#'   and `is_primary`.
 #'
 #' @examples
 #' if (interactive()) {
@@ -26,7 +29,7 @@
 #'   schedule$get_run_sequence()
 #' }
 #' @export
-get_run_sequence <- function(schedule, n = NULL, min_datetime = NULL, max_datetime = NULL, include_only_primary = FALSE) {
+get_run_sequence <- function(schedule, n = NULL, min_datetime = NULL, max_datetime = NULL, include_only_primary = FALSE, include_skipped = TRUE) {
 
   if (!"MaestroSchedule" %in% class(schedule)) {
     cli::cli_abort(
@@ -70,6 +73,13 @@ get_run_sequence <- function(schedule, n = NULL, min_datetime = NULL, max_dateti
     )
   }
 
+  if (!rlang::is_scalar_logical(include_skipped)) {
+    cli::cli_abort(
+      "`include_skipped` must be a boolean.",
+      call = rlang::caller_env()
+    )
+  }
+
   if (!is.null(min_datetime) && !is.null(max_datetime)) {
     if (min_datetime > max_datetime) {
       cli::cli_abort(
@@ -83,6 +93,7 @@ get_run_sequence <- function(schedule, n = NULL, min_datetime = NULL, max_dateti
     n = n,
     min_datetime = min_datetime, 
     max_datetime = max_datetime,
-    include_only_primary = include_only_primary
+    include_only_primary = include_only_primary,
+    include_skipped = include_skipped
   )
 }

--- a/man/MaestroSchedule.Rd
+++ b/man/MaestroSchedule.Rd
@@ -185,7 +185,8 @@ Get full sequence of scheduled executions for all pipelines
   n = NULL,
   min_datetime = NULL,
   max_datetime = NULL,
-  include_only_primary = FALSE
+  include_only_primary = FALSE,
+  include_skipped = TRUE
 )}\if{html}{\out{</div>}}
 }
 
@@ -200,6 +201,9 @@ Get full sequence of scheduled executions for all pipelines
 
 \item{\code{include_only_primary}}{only primary pipelines are included
 (this are pipelines that are scheduled and not downstream nodes in a DAG)}
+
+\item{\code{include_skipped}}{whether to include pipelines tagged with \verb{@maestroSkip}
+(default \code{TRUE} for backwards compatibility)}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/get_run_sequence.Rd
+++ b/man/get_run_sequence.Rd
@@ -9,7 +9,8 @@ get_run_sequence(
   n = NULL,
   min_datetime = NULL,
   max_datetime = NULL,
-  include_only_primary = FALSE
+  include_only_primary = FALSE,
+  include_skipped = TRUE
 )
 }
 \arguments{
@@ -25,9 +26,13 @@ If specified, only returns runs scheduled at or before this datetime.}
 
 \item{include_only_primary}{only primary pipelines are included
 (this are pipelines that are scheduled and not downstream nodes in a DAG)}
+
+\item{include_skipped}{whether to include pipelines tagged with \verb{@maestroSkip}
+(default \code{TRUE} for backwards compatibility)}
 }
 \value{
-A vector of datetime values representing the scheduled run times.
+A data.frame of scheduled run times with columns \code{pipe_name}, \code{scheduled_time},
+and \code{is_primary}.
 }
 \description{
 Retrieves the scheduled run times for a given schedule, with optional filtering

--- a/renv.lock
+++ b/renv.lock
@@ -779,7 +779,7 @@
       "Collate": "'Dates.r' 'POSIXt.r' 'util.r' 'parse.r' 'timespans.r' 'intervals.r' 'difftimes.r' 'durations.r' 'periods.r' 'accessors-date.R' 'accessors-day.r' 'accessors-dst.r' 'accessors-hour.r' 'accessors-minute.r' 'accessors-month.r' 'accessors-quarter.r' 'accessors-second.r' 'accessors-tz.r' 'accessors-week.r' 'accessors-year.r' 'am-pm.r' 'time-zones.r' 'numeric.r' 'coercion.r' 'constants.r' 'cyclic_encoding.r' 'data.r' 'decimal-dates.r' 'deprecated.r' 'format_ISO8601.r' 'guess.r' 'hidden.r' 'instants.r' 'leap-years.r' 'ops-addition.r' 'ops-compare.r' 'ops-division.r' 'ops-integer-division.r' 'ops-m+.r' 'ops-modulo.r' 'ops-multiplication.r' 'ops-subtraction.r' 'package.r' 'pretty.r' 'round.r' 'stamp.r' 'tzdir.R' 'update.r' 'vctrs.R' 'zzz.R'",
       "NeedsCompilation": "yes",
       "Author": "Vitalie Spinu [aut, cre], Garrett Grolemund [aut], Hadley Wickham [aut], Davis Vaughan [ctb], Ian Lyttle [ctb], Imanuel Costigan [ctb], Jason Law [ctb], Doug Mitarotonda [ctb], Joseph Larmarange [ctb], Jonathan Boiser [ctb], Chel Hee Lee [ctb]",
-      "Repository": "https://packagemanager.posit.co/cran/latest"
+      "Repository": "CRAN"
     },
     "magrittr": {
       "Package": "magrittr",
@@ -1064,7 +1064,7 @@
     },
     "purrr": {
       "Package": "purrr",
-      "Version": "1.2.1",
+      "Version": "1.2.2",
       "Source": "Repository",
       "Title": "Functional Programming Tools",
       "Authors@R": "c( person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0003-4757-117X\")), person(\"Lionel\", \"Henry\", , \"lionel@posit.co\", role = \"aut\"), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"https://ror.org/03wc8by49\")) )",
@@ -1538,7 +1538,7 @@
       "NeedsCompilation": "yes",
       "Author": "Vitalie Spinu [aut, cre], Google Inc. [ctb, cph]",
       "Maintainer": "Vitalie Spinu <spinuvit@gmail.com>",
-      "Repository": "https://packagemanager.posit.co/cran/latest"
+      "Repository": "CRAN"
     },
     "utf8": {
       "Package": "utf8",
@@ -1573,7 +1573,7 @@
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.7.2",
+      "Version": "0.7.3",
       "Source": "Repository",
       "Title": "Vector Helpers",
       "Authors@R": "c( person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = \"aut\"), person(\"Lionel\", \"Henry\", , \"lionel@posit.co\", role = \"aut\"), person(\"Davis\", \"Vaughan\", , \"davis@posit.co\", role = c(\"aut\", \"cre\")), person(\"data.table team\", role = \"cph\", comment = \"Radix sort based on data.table's forder() and their contribution to R's order()\"), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")) )",
@@ -1613,6 +1613,7 @@
       "Config/testthat/edition": "3",
       "Config/testthat/parallel": "true",
       "Encoding": "UTF-8",
+      "KeepSource": "true",
       "Language": "en-GB",
       "RoxygenNote": "7.3.3",
       "NeedsCompilation": "yes",

--- a/tests/testthat/test-get_run_sequence.R
+++ b/tests/testthat/test-get_run_sequence.R
@@ -26,6 +26,8 @@ test_that("get_run_sequence works", {
   expect_in(c("p1", "p2", "p3"), unique(run_seq$pipe_name))
   expect_equal(nrow(run_seq), 30L)
   expect_s3_class(run_seq$scheduled_time, "POSIXct")
+  expect_true("is_primary" %in% names(run_seq))
+  expect_true(all(run_seq$is_primary))
 })
 
 test_that("informative error messages on invalid params", {
@@ -70,6 +72,11 @@ test_that("informative error messages on invalid params", {
     get_run_sequence(schedule, include_only_primary = "a"),
     regexp = "must be a boolean"
   )
+
+  expect_error(
+    get_run_sequence(schedule, include_skipped = "a"),
+    regexp = "must be a boolean"
+  )
 })
 
 test_that("dags are properly represented", {
@@ -102,9 +109,46 @@ test_that("dags are properly represented", {
   expect_s3_class(run_seq$scheduled_time, "POSIXct")
   expect_true(!any(is.na(run_seq$scheduled_time)))
 
+  # is_primary: p1 is root, p2 and p3 are downstream
+  expect_true(all(run_seq$is_primary[run_seq$pipe_name == "p1"]))
+  expect_true(all(!run_seq$is_primary[run_seq$pipe_name %in% c("p2", "p3")]))
+
   run_seq <- get_run_sequence(schedule, n = 10, include_only_primary = TRUE)
   expect_true(all(run_seq$pipe_name == "p1"))
   expect_equal(nrow(run_seq), 10L)
   expect_s3_class(run_seq$scheduled_time, "POSIXct")
   expect_true(!any(is.na(run_seq$scheduled_time)))
+})
+
+test_that("include_skipped = FALSE excludes skipped pipelines", {
+
+  withr::with_tempdir({
+    dir.create("pipelines")
+    writeLines(
+      "
+      #' @maestroFrequency hourly
+      p1 <- function() {
+      }
+
+      #' @maestroFrequency 2 hours
+      #' @maestroSkip
+      p2 <- function() {
+      }
+
+      #' @maestroFrequency 3 hours
+      p3 <- function() {
+      }
+      ",
+      con = "pipelines/pipes.R"
+    )
+
+    schedule <- build_schedule(quiet = TRUE)
+  })
+
+  run_seq_all <- get_run_sequence(schedule, n = 10, include_skipped = TRUE)
+  expect_in(c("p1", "p2", "p3"), unique(run_seq_all$pipe_name))
+
+  run_seq_no_skip <- get_run_sequence(schedule, n = 10, include_skipped = FALSE)
+  expect_false("p2" %in% unique(run_seq_no_skip$pipe_name))
+  expect_in(c("p1", "p3"), unique(run_seq_no_skip$pipe_name))
 })


### PR DESCRIPTION
# maestro 1.1.0.9001

### Breaking changes

- The default value for `maestroStartTime` is no longer fixed to 2024-01-01 00:00:00 but is now dynamic based on the frequency of the pipeline. Daily or more frequent is midnight of the current build day, weekly is beginning of the current week, and so on for lower frequencies.

### New features

- `get_run_sequence()` now returns an `is_primary` column: `TRUE` for pipelines that are not downstream nodes in a DAG (i.e., root or standalone pipelines), `FALSE` for downstream DAG nodes.

- `get_run_sequence()` gains an `include_skipped` argument (default `TRUE`). Set to `FALSE` to exclude pipelines tagged with `@maestroSkip` from the output.

- `maestroStartTime` now accepts partial anchor formats, making it easier to express natural cycle points without picking a specific date:
  - `Mon HH:MM:SS` (weekday + time) — for weekly pipelines, e.g. `Mon 04:00:00` runs every Monday at 4am.
  - `DD HH:MM:SS` or `DD` (month-day + optional time) — for monthly pipelines, e.g. `15 04:00:00` runs on the 15th of every month at 4am.

### Deprecated functionality

- `suggest_orch_frequency()` is deprecated with no replacement.

- `show_network()` (and `MaestroSchedule$show_network()`) is deprecated due to
  its reliance on `DiagrammeR`, which brings in a large number of little-used dependencies. Use `get_network()` to retrieve the pipeline dependency edge list directly.

### Minor changes

- Some optimizations in schedule building and running.

- Schedules no longer store run_sequences, but are rather built lazily as needed. This greatly improves the portability of schedule objects making it more practical in production to cache a schedule as an RDS to avoid re-parsing tags.